### PR TITLE
Update read_header function to support EFM data Files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - [#41](https://github.com/bcliang/gamry-parser/pull/40) Use tox as test runner
 
 ### Added
--
+- [#42](https://github.com/bcliang/gamry-parser/pull/42) Update read_header function to support EFM140 data Files
 
 ## [0.4.4] - 2021-02-28
 

--- a/gamry_parser/gamryparser.py
+++ b/gamry_parser/gamryparser.py
@@ -164,7 +164,7 @@ class GamryParser:
         pos = 0
         with open(self.fname, "r", encoding="utf8", errors="ignore") as f:
             cur_line = f.readline().split("\t")
-            while not re.search(r"(^|Z|VFP)CURVE", cur_line[0]):
+            while not re.search(r"(^|Z|VFP|EFM)CURVE", cur_line[0]):
                 if f.tell() == pos:
                     break
 


### PR DESCRIPTION
EFM datafiles are generated by [EFM140](https://www.gamry.com/support/software/efm140-electrochemical-frequency-modulation/) Software which is part of the Gamry Software modules.
When I tried to parse an EFM .DTA file, no curves were detected by the parser.
The reason is because in this files the curve data starts after a "**EFMCURVE**" tag.

So, I add the letters "EFM" to the regex on the `read_header` function. 
Now the EFM  curve is detected and everything works fine.

Here is an example EFM file:
[GEN_EFM_#3.DTA](https://drive.google.com/file/d/1OcGX-0FHC6UC8n0f6ryxLELOEIW78agm/view?usp=sharing)
